### PR TITLE
Filter in Tags and Authors

### DIFF
--- a/Packages/Sites/Sfi.Kateheo/Configuration/NodeTypes.yaml
+++ b/Packages/Sites/Sfi.Kateheo/Configuration/NodeTypes.yaml
@@ -186,7 +186,7 @@ blah: &alohaRich
           group: news
           editorOptions:
             nodeTypes:
-              - 'TYPO3.Neos:Document'
+              - 'Sfi.Kateheo:Author'
     tags:
       type: references
       ui:
@@ -196,6 +196,6 @@ blah: &alohaRich
           group: news
           editorOptions:
             nodeTypes:
-              - 'TYPO3.Neos:Document'
+              - 'Sfi.Kateheo:Tags'
     originalIdentifier:
       type: string


### PR DESCRIPTION
Filter restriction added for filtering not by TYPO3.Neos.Document but by the type of an element.
